### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,76 @@
+name: Deploy
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test_ci:
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.10.0
+          architecture: "x64"
+      - uses: actions/cache@v4.0.2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install pip requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Python unit tests
+        run: |
+          python -m unittest discover -s test -p "*.py"
+
+  deploy:
+    runs-on: ubuntu-20.04
+    needs: test_ci
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: 3.10.0
+          architecture: "x64"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
+      - name: Install pip requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/s-mishina/flexiblemockserver:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*/__pycache__
+*/__init__.py

--- a/project/main.py
+++ b/project/main.py
@@ -66,6 +66,9 @@ def only_status_code_query(status_code, sleep_time=0):
     else:
         return make_response(jsonify(err="Not status code"), 400)
 
+@app.errorhandler(404)
+def page_not_found(e):
+    return make_response(jsonify(err="Nonexistent Path"), 404)
 
 if __name__ == '__main__':
     app.run(host=host, port=port)

--- a/test/app_unittest.py
+++ b/test/app_unittest.py
@@ -1,5 +1,7 @@
 import unittest
-from main import app
+
+from project.main import app
+
 
 class TestApp(unittest.TestCase):
     def setUp(self):
@@ -47,5 +49,7 @@ class TestApp(unittest.TestCase):
         self.assertEqual(response.json['status_code'], 500)
         self.assertEqual(response.json['output'], "{'param1': 'value1', 'param2': 'value2'}")
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_new_route(self):
+        response = self.app.get('/new')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json['err'], 'Nonexistent Path')


### PR DESCRIPTION
This excerpt from deploy.yaml outlines two jobs in our GitHub Actions workflow: a testing job and a deployment job.

The testing job begins by setting up Python using actions/setup-python@v5.1.0, specifying Python version 3.10.0 and an x64 architecture. It then sets up caching for pip dependencies using actions/cache@v4.0.2, which will significantly speed up future workflow runs by reusing previously installed packages. The cache key is dependent on the runner OS and the hash of requirements.txt, ensuring the cache is updated whenever our dependencies change. After setting up the cache, the workflow installs the pip requirements from requirements.txt and runs Python unit tests.

The deployment job, which depends on the successful completion of the testing job (needs: test_ci), is set to run only when a pull request is merged (if: github.event.pull_request.merged == true). This job also begins by setting up Python and checking out the code. The remaining steps for this job (not shown in the excerpt) would typically involve building and pushing a Docker image, or deploying the application to a server.