### PR TITLE
Refactor main.py for Better Error Handling and Application Startup

### DIFF
--- a/project/main.py
+++ b/project/main.py
@@ -15,8 +15,8 @@ HTTP_METHODS = ['GET', 'HEAD', 'POST', 'PUT',
 def top():
     return make_response(jsonify(top='Hello mock server'), 200)
 
-
 @app.route('/<int:sleep_time>/<int:status_code>', methods=HTTP_METHODS)
+@app.route('/<int:sleep_time>/<int:status_code>/', methods=HTTP_METHODS)
 def index(sleep_time, status_code):
     if 100 <= status_code <= 599:
         time.sleep(sleep_time)
@@ -24,21 +24,20 @@ def index(sleep_time, status_code):
     else:
         return make_response(jsonify(err="Not status code"), 400)
 
-
-@app.route('/sleep/<int:sleep_time>/', defaults={'status_code': 200}, methods=HTTP_METHODS)
-def only_sleep_time(sleep_time, status_code):
+@app.route('/sleep/<int:sleep_time>', methods=HTTP_METHODS)
+@app.route('/sleep/<int:sleep_time>/', methods=HTTP_METHODS)
+def only_sleep_time(sleep_time):
     time.sleep(sleep_time)
-    return make_response(jsonify(sleep_time=sleep_time, status_code=status_code), status_code)
-
+    return make_response(jsonify(sleep_time=sleep_time, status_code=200), 200)
 
 @app.route('/status/<int:status_code>', methods=HTTP_METHODS)
+@app.route('/status/<int:status_code>/', methods=HTTP_METHODS)
 def only_status_code(status_code, sleep_time=0):
     if 100 <= status_code <= 599:
         time.sleep(sleep_time)
         return make_response(jsonify(sleep_time=sleep_time, status_code=status_code), status_code)
     else:
         return make_response(jsonify(err="Not status code"), 400)
-
 
 @app.route('/<int:sleep_time>/<int:status_code>/query', methods=HTTP_METHODS)
 def index_query(sleep_time, status_code):

--- a/test/app_unittest.py
+++ b/test/app_unittest.py
@@ -18,7 +18,19 @@ class TestApp(unittest.TestCase):
         self.assertEqual(response.json['sleep_time'], 5)
         self.assertEqual(response.json['status_code'], 200)
 
+    def test_index_route_1(self):
+        response = self.app.get('/5/200/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['sleep_time'], 5)
+        self.assertEqual(response.json['status_code'], 200)
+
     def test_only_sleep_time_route(self):
+        response = self.app.get('/sleep/3')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['sleep_time'], 3)
+        self.assertEqual(response.json['status_code'], 200)
+
+    def test_only_sleep_time_route_1(self):
         response = self.app.get('/sleep/3/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json['sleep_time'], 3)
@@ -26,6 +38,11 @@ class TestApp(unittest.TestCase):
 
     def test_only_status_code_route(self):
         response = self.app.get('/status/404')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json['status_code'], 404)
+
+    def test_only_status_code_route(self):
+        response = self.app.get('/status/404/')
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json['status_code'], 404)
 


### PR DESCRIPTION
# sample 

* before

```
@app.route('/status/<int:status_code>', methods=HTTP_METHODS)
def only_status_code(status_code, sleep_time=0):
```

* after

```
@app.route('/status/<int:status_code>', methods=HTTP_METHODS)
@app.route('/status/<int:status_code>/', methods=HTTP_METHODS)
def only_status_code(status_code, sleep_time=0):
```

# summary

In the code before the change, matching occurs only when there is no trailing slash (/) in the URL. That is, /status/200/ will match, but /status/200/ will not.

In Flask routing, trailing slashes have a special meaning. If a trailing slash is present, accesses to URLs without that slash are automatically redirected to URLs with the slash. Conversely, if there is no trailing slash, access to a URL with a trailing slash will return a 308 error.

Thus, this change is intended to allow access to URLs with trailing slashes (such as /status/200/), thereby ensuring that the same view is used whether the URL has a trailing slash or not. This allows for normal operation even if the user forgets to add a trailing slash.