### PR TITLE
fix: 🐛 Remove Jinja2 dependency from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==8.1.3
 Flask==2.3.3
 itsdangerous==2.2.0
-Jinja2==3.1.4
 MarkupSafe==2.1.5
 Werkzeug==3.0.3
 PyYAML==6.0.1


### PR DESCRIPTION
## issue

https://github.com/S-mishina/flexiblemockserver/security/dependabot/13
https://github.com/S-mishina/flexiblemockserver/security/dependabot/12
https://github.com/S-mishina/flexiblemockserver/security/dependabot/10

## Summary

library delete

