### PR TITLE
fix: correct permissions placement in workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,65 +7,20 @@ on:
     types: [opened, synchronize, closed]
 
 jobs:
-  test_ci:
-    runs-on: ubuntu-20.04
+  test:
+    uses: S-mishina/reusable-workflows/.github/workflows/python-test-pip.yml@main
+    with:
+      python-version: "3.12"
+      test-command: "python -m unittest discover -s test -p '*.py'"
     permissions:
-      packages: write
       contents: read
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: 3.12.0
-          architecture: "x64"
-      - name: Install pip requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run Python unit tests
-        run: |
-          python -m unittest discover -s test -p "*.py"
 
   deploy:
-    runs-on: ubuntu-20.04
-    needs: test_ci
+    needs: test
     if: github.event.pull_request.merged == true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: 3.12.0
-          architecture: "x64"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.3.0
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
-      - name: Install pip requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          logout: false
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/s-mishina/flexiblemockserver:${{ github.sha }}
-            ghcr.io/s-mishina/flexiblemockserver:latest
+    uses: S-mishina/reusable-workflows/.github/workflows/docker-build-push.yml@main
+    with:
+      image-name: s-mishina/flexiblemockserver
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,19 +8,19 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     uses: S-mishina/reusable-workflows/.github/workflows/python-test-pip.yml@main
     with:
       python-version: "3.12"
       test-command: "python -m unittest discover -s test -p '*.py'"
-    permissions:
-      contents: read
 
   deploy:
+    permissions:
+      contents: read
+      packages: write
     needs: test
     if: github.event.pull_request.merged == true
     uses: S-mishina/reusable-workflows/.github/workflows/docker-build-push.yml@main
     with:
       image-name: s-mishina/flexiblemockserver
-    permissions:
-      contents: read
-      packages: write

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 256
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
This pull request streamlines the CI/CD workflow by switching to reusable workflows for both testing and deployment, and introduces a YAML linter configuration to enforce code style. The most important changes are:

**CI/CD Workflow Improvements:**

* Replaced the custom test and deploy job definitions in `.github/workflows/deploy.yaml` with calls to reusable workflows (`python-test-pip.yml` and `docker-build-push.yml`), simplifying the workflow configuration and maintenance.
* Updated job names and permissions to align with the new reusable workflow structure, ensuring correct access and execution order.

**Linting and Code Quality:**

* Added a `.yamllint.yaml` configuration file to enable YAML linting with custom rules for line length, truthy value checking, and comment formatting, helping maintain consistent YAML style across the repository.